### PR TITLE
feat: Add AI Insights link to navigation

### DIFF
--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -402,6 +402,12 @@
                     </a>
                 </li>
                 <li class="nav-item">
+                    <a href="{% url 'summary' %}" class="nav-link">
+                        <i class="fas fa-lightbulb fa-fw"></i>
+                        <span>AI Insights</span>
+                    </a>
+                </li>
+                <li class="nav-item">
                     <a href="#" class="nav-link"><i class="fas fa-history fa-fw"></i><span>Chat History</span></a>
                 </li>
                 <li class="nav-item">

--- a/templates/base.html
+++ b/templates/base.html
@@ -333,6 +333,9 @@
                     <li class="nav-item">
                         <a class="nav-link {% if 'dashboard' in request.path or 'analytics' in request.path %}active{% endif %}" href="{% url 'dashboard' %}">Dashboard</a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link {% if 'summary' in request.path %}active{% endif %}" href="{% url 'summary' %}"><i class="fas fa-lightbulb me-1"></i>AI Insights</a>
+                    </li>
                     {% if user.is_staff %}
                     <li class="nav-item">
                         <a class="nav-link" href="/admin/">Admin</a>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -484,6 +484,12 @@
                     </a>
                 </li>
                 <li class="nav-item">
+                    <a href="{% url 'summary' %}" class="nav-link">
+                        <i class="fas fa-lightbulb fa-fw"></i>
+                        <span>AI Insights</span>
+                    </a>
+                </li>
+                <li class="nav-item">
                     <a href="#" class="nav-link">
                         <i class="fas fa-history fa-fw"></i>
                         <span>Chat History</span>


### PR DESCRIPTION
Added a consistent link to the "AI Insights" page (Summary.html) across multiple dashboard-related pages.

Modifications:
- `templates/base.html`: Added "AI Insights" link to the main navbar for authenticated users.
- `templates/dashboard.html`: Added "AI Insights" link to the side navigation bar.
- `templates/analytics.html`: Added "AI Insights" link to the side navigation bar.
- `templates/summary.html`: Already inherits the link from `base.html` and displays the common navbar.

The new link includes an icon and appropriate active state handling where applicable.