### PR TITLE
refactor: Update summary.html to use dashboard navigation layout

### DIFF
--- a/templates/summary.html
+++ b/templates/summary.html
@@ -1,189 +1,518 @@
-{% extends "base.html" %}
 {% load math_extras %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AccountAssist - AI Summary</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <style>
+        :root {
+            /* Primary Colors */
+            --primary-color: #2A52BE; /* Primary Blue - Trust & Stability */
+            --primary-hover: #1E3D8B;
+            --secondary-color: #4DB8BA; /* Secondary Blue/Teal - Modernity */
+            --secondary-hover: #3A9A9C;
+            --accent-color: #28A745; /* Accent Green - Growth & Positivity */
 
-{% block content %}
-<style>
-    /* Styles specific to summary.html, complementing base.html */
-    .summary-page-container {
-        padding-top: 40px;
-        padding-bottom: 60px;
-    }
+            /* Neutral Colors */
+            --text-primary: #343A40; /* Dark Gray - Primary Text */
+            --text-secondary: #6C757D; /* Medium Gray - Secondary Text */
+            --text-light: #ADB5BD; /* Light Gray - Subtle Text */
+            --bg-main: #F8F9FA; /* Very Light Gray - Background */
+            --bg-card: #FFFFFF; /* White - Card Backgrounds */
+            --bg-navbar-top: rgba(255, 255, 255, 0.95);
+            --bg-navbar-side: linear-gradient(180deg, var(--primary-color) 0%, var(--primary-hover) 100%);
+            --border-color: #DEE2E6; /* Light border color */
 
-    .summary-page-title {
-        font-size: 2.5rem;
-        font-weight: 700;
-        color: var(--text-primary);
-        margin-bottom: 2.5rem;
-        text-align: center;
-    }
+            /* Feedback Colors */
+            --success-color: #28A745; /* Success Green */
+            --danger-color: #DC3545; /* Error/Danger Red */
+            --warning-color: #FFC107; /* Warning Yellow */
+            --info-color: #4DB8BA; /* Info Teal (matches secondary) */
 
-    /* Key Metric Cards */
-    .metric-card {
-        border-radius: var(--border-radius-lg);
-        color: white;
-        padding: 2rem 1.5rem;
-        margin-bottom: 1.5rem;
-        box-shadow: var(--shadow-medium);
-        transition: transform 0.2s ease-in-out;
-    }
-    .metric-card:hover {
-        transform: translateY(-5px);
-    }
+            /* Shadows */
+            --shadow-soft: 0 4px 12px rgba(42, 82, 190, 0.08);
+            --shadow-medium: 0 8px 24px rgba(42, 82, 190, 0.12);
 
-    .metric-card h5 { /* Metric Title */
-        font-size: 1.1rem;
-        font-weight: 500;
-        margin-bottom: 0.75rem;
-        opacity: 0.9;
-        color: white;
-    }
-    .metric-card h2 { /* Metric Value */
-        font-size: 2.5rem;
-        font-weight: 700;
-        margin-bottom: 0;
-        color: white;
-    }
+            --font-main: 'Inter', sans-serif;
+            --border-radius-sm: 0.375rem; /* 6px */
+            --border-radius-md: 0.75rem; /* 12px */
+            --border-radius-lg: 1rem; /* 16px */
+        }
 
-    .bg-metric-income { background: linear-gradient(135deg, var(--success-color), #238C3F); } /* Darker green */
-    .bg-metric-expense { background: linear-gradient(135deg, var(--danger-color), #B82B39); } /* Darker red */
-    .bg-metric-cashflow { background: linear-gradient(135deg, var(--secondary-color), var(--primary-color)); } /* Teal to Blue */
+        body {
+            font-family: var(--font-main);
+            background-color: var(--bg-main);
+            color: var(--text-primary);
+            margin: 0;
+            padding: 0;
+            font-weight: 400;
+            overflow-x: hidden; /* Prevent horizontal scroll */
+        }
+
+        /* Top Navbar */
+        .top-navbar {
+            background-color: var(--bg-navbar-top);
+            backdrop-filter: blur(8px);
+            box-shadow: var(--shadow-soft);
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            z-index: 1040;
+            height: 65px; /* Slightly taller */
+            padding: 0 1.5rem;
+        }
+
+        .navbar-brand {
+            font-weight: 800;
+            color: var(--primary-color) !important;
+            font-size: 1.6rem;
+            display: flex;
+            align-items: center;
+        }
+        .navbar-brand i {
+            color: var(--secondary-color);
+            margin-right: 0.6rem;
+            font-size: 1.5rem;
+        }
+        .top-navbar .text-muted {
+            color: var(--text-secondary) !important;
+        }
+        .top-navbar .btn-outline-danger {
+            color: var(--danger-color);
+            border-color: var(--danger-color);
+            font-weight: 500;
+            padding: 0.4rem 0.8rem;
+            font-size: 0.9rem;
+        }
+        .top-navbar .btn-outline-danger:hover {
+            background-color: var(--danger-color);
+            color: white;
+        }
 
 
-    /* Insights Card */
-    .insights-card {
-        border-radius: var(--border-radius-lg);
-        box-shadow: var(--shadow-soft);
-        background-color: var(--bg-card);
-    }
-    .insights-card .card-header {
-        background-color: transparent;
-        border-bottom: 1px solid var(--border-color);
-        padding: 1.5rem;
-    }
-    .insights-card .card-header h5 {
-        font-size: 1.5rem;
-        font-weight: 700;
-        color: var(--primary-color);
-        margin: 0;
-        display: flex;
-        align-items: center;
-    }
-    .insights-card .card-header i {
-        margin-right: 0.75rem;
-        color: var(--accent-color); /* Gold icon */
-    }
+        /* Main Layout */
+        .main-wrapper {
+            margin-top: 65px;
+            display: flex;
+            min-height: calc(100vh - 65px);
+        }
 
-    .insights-content {
-        padding: 1.5rem 2rem; /* More padding for readability */
-        line-height: 1.8;
-        font-size: 1.05rem; /* Slightly larger for content */
-        color: var(--text-secondary);
-        white-space: pre-line; /* Preserve line breaks from template */
-    }
+        /* Side Navigation */
+        .side-navbar {
+            width: 270px; /* Slightly wider */
+            background: var(--bg-navbar-side);
+            color: white;
+            position: fixed;
+            left: 0;
+            top: 65px;
+            bottom: 0;
+            overflow-y: auto;
+            transition: transform 0.3s ease-in-out;
+            z-index: 1030;
+            padding-top: 1.5rem;
+            box-shadow: 3px 0 15px rgba(0,0,0,0.05);
+        }
 
-    .insights-content h2, .insights-content h3 { /* Headings within insights */
-        color: var(--text-primary);
-        margin-top: 1.5rem;
-        margin-bottom: 1rem;
-        font-weight: 600;
-    }
-    .insights-content h2 { font-size: 1.4rem; }
-    .insights-content h3 { font-size: 1.2rem; }
+        .side-navbar-header {
+            padding: 0 1.5rem 1.5rem 1.5rem;
+            border-bottom: 1px solid rgba(255,255,255,0.15);
+        }
 
-    .insights-content ul, .insights-content ol {
-        padding-left: 1.5rem; /* Indent lists */
-        margin-bottom: 1rem;
-    }
-    .insights-content li {
-        margin-bottom: 0.5rem;
-    }
-    .insights-content strong {
-        font-weight: 600;
-        color: var(--text-primary);
-    }
-    .insights-content code { /* If you use code blocks for anything */
-        background-color: #f0f0f0;
-        padding: 0.2em 0.4em;
-        border-radius: var(--border-radius-sm);
-        font-size: 0.9em;
-    }
+        .user-profile {
+            text-align: center;
+            margin-bottom: 1.5rem;
+        }
 
-    .insights-actions {
-        padding: 1.5rem 2rem;
-        border-top: 1px solid var(--border-color);
-        background-color: #FDFDFD; /* Slightly off-white footer */
-        border-bottom-left-radius: var(--border-radius-lg);
-        border-bottom-right-radius: var(--border-radius-lg);
-    }
-    .insights-actions .btn {
-        margin-right: 0.75rem;
-        font-weight: 500;
-    }
-    .insights-actions .btn i {
-        margin-right: 0.5rem;
-    }
-    .insights-actions .btn-primary {
-        background-color: var(--primary-color);
-        border-color: var(--primary-color);
-    }
-    .insights-actions .btn-primary:hover {
-        background-color: var(--primary-hover);
-        border-color: var(--primary-hover);
-    }
-    .insights-actions .btn-success { /* For action items */
-        background-color: var(--accent-color); /* Gold for CTA */
-        border-color: var(--accent-color);
-        color: var(--text-primary); /* Dark text on gold */
-    }
-    .insights-actions .btn-success:hover {
-        background-color: #DDA200; /* Darker gold */
-        border-color: #DDA200;
-    }
+        .user-avatar i {
+            color: rgba(255,255,255,0.7);
+            margin-bottom: 0.75rem;
+            font-size: 3.5rem;
+        }
 
-</style>
+        .user-profile h6 {
+            font-weight: 600;
+            margin-bottom: 0.25rem;
+            color: white;
+            font-size: 1.1rem;
+        }
 
-<div class="container summary-page-container">
-    <h1 class="summary-page-title">Actionable Financial Insights</h1>
+        .user-profile .text-muted { /* Override bootstrap */
+            color: rgba(255,255,255,0.7) !important;
+            font-size: 0.875rem;
+        }
 
-    <div class="row mt-4 mb-5">
-        <div class="col-md-4">
-            <div class="metric-card bg-metric-income">
-                <h5>30-Day Income</h5>
-                <h2>₹{{ total_income|default:0|floatformat:2 }}</h2>
-            </div>
+        .nav-menu {
+            padding: 1rem 1rem; /* Padding around the menu items */
+        }
+
+        .nav-menu .nav-link {
+            color: rgba(255, 255, 255, 0.8);
+            font-weight: 500;
+            font-size: 0.95rem;
+            padding: 0.85rem 1.25rem; /* Increased padding */
+            margin-bottom: 0.35rem;
+            border-radius: var(--border-radius-md);
+            transition: all 0.25s ease;
+            display: flex;
+            align-items: center;
+        }
+
+        .nav-menu .nav-link:hover,
+        .nav-menu .nav-item.active .nav-link {
+            color: var(--primary-color);
+            background-color: white;
+            transform: translateX(5px);
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+        }
+        .nav-menu .nav-item.active .nav-link {
+             font-weight: 600;
+        }
+
+        .nav-menu .nav-link i {
+            width: 22px; /* Icon width */
+            margin-right: 0.85rem;
+            font-size: 1.1rem; /* Icon size */
+        }
+
+        /* Content Area */
+        .content-wrapper {
+            margin-left: 270px;
+            flex: 1;
+            padding: 2rem; /* Consistent padding for content area */
+            background-color: var(--bg-main);
+            transition: margin-left 0.3s ease-in-out;
+        }
+
+        /* Mobile Responsiveness */
+        .mobile-toggle {
+            display: none; /* Hidden by default */
+            position: fixed;
+            top: 12px; /* Align with top navbar */
+            left: 1rem;
+            z-index: 1045; /* Above side-navbar when closed */
+            background: var(--primary-color);
+            color: white;
+            border: none;
+            border-radius: 50%;
+            width: 40px;
+            height: 40px;
+            box-shadow: var(--shadow-medium);
+            transition: background-color 0.2s ease;
+        }
+        .mobile-toggle:hover {
+            background: var(--primary-hover);
+        }
+
+
+        @media (max-width: 992px) { /* Breakpoint for sidebar toggle */
+            .side-navbar {
+                transform: translateX(-270px);
+            }
+            .side-navbar.active {
+                transform: translateX(0);
+                box-shadow: 5px 0 25px rgba(0,0,0,0.15);
+            }
+            .content-wrapper {
+                margin-left: 0;
+            }
+            .mobile-toggle {
+                display: inline-block;
+            }
+            .top-navbar {
+                padding-left: 4rem; /* Space for toggle button */
+            }
+        }
+
+        @media (max-width: 768px) {
+            .content-wrapper {
+                padding: 1rem; /* Adjust padding for smaller screens */
+            }
+             .top-navbar .navbar-brand { font-size: 1.3rem; }
+             .top-navbar .navbar-brand i { font-size: 1.2rem; }
+             .top-navbar .text-muted strong { display: none; } /* Hide username on small screens */
+        }
+    </style>
+
+    <!-- Styles specific to summary.html -->
+    <style>
+        .summary-page-container {
+            /* padding-top: 40px; */ /* Handled by content-wrapper */
+            /* padding-bottom: 60px; */ /* Handled by content-wrapper */
+        }
+
+        .summary-page-title {
+            font-size: 2.5rem;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 2.5rem;
+            text-align: center;
+        }
+
+        .metric-card {
+            border-radius: var(--border-radius-lg);
+            color: white;
+            padding: 2rem 1.5rem;
+            margin-bottom: 1.5rem;
+            box-shadow: var(--shadow-medium);
+            transition: transform 0.2s ease-in-out;
+        }
+        .metric-card:hover {
+            transform: translateY(-5px);
+        }
+
+        .metric-card h5 {
+            font-size: 1.1rem;
+            font-weight: 500;
+            margin-bottom: 0.75rem;
+            opacity: 0.9;
+            color: white;
+        }
+        .metric-card h2 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0;
+            color: white;
+        }
+
+        .bg-metric-income { background: linear-gradient(135deg, var(--success-color), #238C3F); }
+        .bg-metric-expense { background: linear-gradient(135deg, var(--danger-color), #B82B39); }
+        .bg-metric-cashflow { background: linear-gradient(135deg, var(--secondary-color), var(--primary-color)); }
+
+        .insights-card {
+            border-radius: var(--border-radius-lg);
+            box-shadow: var(--shadow-soft);
+            background-color: var(--bg-card);
+        }
+        .insights-card .card-header {
+            background-color: transparent;
+            border-bottom: 1px solid var(--border-color);
+            padding: 1.5rem;
+        }
+        .insights-card .card-header h5 {
+            font-size: 1.5rem;
+            font-weight: 700;
+            color: var(--primary-color);
+            margin: 0;
+            display: flex;
+            align-items: center;
+        }
+        .insights-card .card-header i {
+            margin-right: 0.75rem;
+            color: var(--accent-color);
+        }
+
+        .insights-content {
+            padding: 1.5rem 2rem;
+            line-height: 1.8;
+            font-size: 1.05rem;
+            color: var(--text-secondary);
+            white-space: pre-line;
+        }
+        .insights-content h2, .insights-content h3 {
+            color: var(--text-primary);
+            margin-top: 1.5rem;
+            margin-bottom: 1rem;
+            font-weight: 600;
+        }
+        .insights-content h2 { font-size: 1.4rem; }
+        .insights-content h3 { font-size: 1.2rem; }
+        .insights-content ul, .insights-content ol {
+            padding-left: 1.5rem;
+            margin-bottom: 1rem;
+        }
+        .insights-content li { margin-bottom: 0.5rem; }
+        .insights-content strong {
+            font-weight: 600;
+            color: var(--text-primary);
+        }
+        .insights-content code {
+            background-color: #f0f0f0;
+            padding: 0.2em 0.4em;
+            border-radius: var(--border-radius-sm);
+            font-size: 0.9em;
+        }
+
+        .insights-actions {
+            padding: 1.5rem 2rem;
+            border-top: 1px solid var(--border-color);
+            background-color: #FDFDFD;
+            border-bottom-left-radius: var(--border-radius-lg);
+            border-bottom-right-radius: var(--border-radius-lg);
+        }
+        .insights-actions .btn {
+            margin-right: 0.75rem;
+            font-weight: 500;
+        }
+        .insights-actions .btn i { margin-right: 0.5rem; }
+        .insights-actions .btn-primary {
+            background-color: var(--primary-color);
+            border-color: var(--primary-color);
+        }
+        .insights-actions .btn-primary:hover {
+            background-color: var(--primary-hover);
+            border-color: var(--primary-hover);
+        }
+        .insights-actions .btn-success {
+            background-color: var(--accent-color);
+            border-color: var(--accent-color);
+            color: var(--text-primary);
+        }
+        .insights-actions .btn-success:hover {
+            background-color: #DDA200;
+            border-color: #DDA200;
+        }
+    </style>
+</head>
+<body>
+    <nav class="navbar navbar-expand top-navbar">
+        <button class="mobile-toggle" id="mobileToggle" aria-label="Toggle sidebar">
+            <i class="fas fa-bars"></i>
+        </button>
+
+        <a class="navbar-brand" href="/">
+            <i class="fas fa-calculator"></i>
+            AccountAssist
+        </a>
+        <div class="ms-auto d-flex align-items-center">
+            <span class="me-3 text-muted d-none d-md-inline">Welcome, <strong>{{ user.username }}</strong></span>
+            <a href="{% url 'logout' %}" class="btn btn-outline-danger btn-sm">
+                <i class="fas fa-sign-out-alt me-1"></i>
+                Logout
+            </a>
         </div>
-        <div class="col-md-4">
-            <div class="metric-card bg-metric-expense">
-                <h5>30-Day Expenses</h5>
-                <h2>₹{{ total_expenses|default:0|floatformat:2 }}</h2>
+    </nav>
+
+    <div class="main-wrapper">
+        <div class="side-navbar" id="sideNavbar">
+            <div class="side-navbar-header">
+                <div class="user-profile">
+                    <div class="user-avatar">
+                        <i class="fas fa-user-circle"></i>
+                    </div>
+                    <h6>{{ user.username }}</h6>
+                    <p class="text-muted small mb-0">{{ user.email }}</p>
+                </div>
             </div>
+            <ul class="nav-menu list-unstyled">
+                <li class="nav-item"> <!-- Chat link, no longer active -->
+                    <a href="{% url 'dashboard' %}" class="nav-link">
+                        <i class="fas fa-comments fa-fw"></i>
+                        <span>Chat</span>
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a href="/analytics/" class="nav-link">
+                        <i class="fas fa-chart-bar fa-fw"></i>
+                        <span>Analytics</span>
+                    </a>
+                </li>
+                <li class="nav-item active"> <!-- AI Insights link, now active -->
+                    <a href="{% url 'summary' %}" class="nav-link">
+                        <i class="fas fa-lightbulb fa-fw"></i>
+                        <span>AI Insights</span>
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a href="#" class="nav-link">
+                        <i class="fas fa-history fa-fw"></i>
+                        <span>Chat History</span>
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a href="#" class="nav-link">
+                        <i class="fas fa-folder fa-fw"></i>
+                        <span>Documents</span>
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a href="#" class="nav-link">
+                        <i class="fas fa-cog fa-fw"></i>
+                        <span>Settings</span>
+                    </a>
+                </li>
+            </ul>
         </div>
-        <div class="col-md-4">
-            <div class="metric-card bg-metric-cashflow">
-                <h5>Net Cash Flow (30-Day)</h5>
-                <h2>₹{{ total_income|subtract:total_expenses|default:0|floatformat:2 }}</h2>
+
+        <div class="content-wrapper">
+            <!-- Original summary.html content (excluding extends and block tags) goes here -->
+            <div class="container summary-page-container">
+                <h1 class="summary-page-title">Actionable Financial Insights</h1>
+
+                <div class="row mt-4 mb-5">
+                    <div class="col-md-4">
+                        <div class="metric-card bg-metric-income">
+                            <h5>30-Day Income</h5>
+                            <h2>₹{{ total_income|default:0|floatformat:2 }}</h2>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="metric-card bg-metric-expense">
+                            <h5>30-Day Expenses</h5>
+                            <h2>₹{{ total_expenses|default:0|floatformat:2 }}</h2>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="metric-card bg-metric-cashflow">
+                            <h5>Net Cash Flow (30-Day)</h5>
+                            <h2>₹{{ total_income|subtract:total_expenses|default:0|floatformat:2 }}</h2>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card insights-card shadow mb-4">
+                    <div class="card-header">
+                        <h5>
+                            <i class="fas fa-lightbulb"></i> AI-Generated Action Plan
+                        </h5>
+                    </div>
+                    <div class="card-body insights-content">
+                        {{ insights|default:"No insights available at the moment. Please check back later or ensure your financial data is up to date." }}
+                    </div>
+
+                    <div class="insights-actions">
+                        <button class="btn btn-primary">
+                            <i class="fas fa-download"></i> Export as PDF
+                        </button>
+                        <button class="btn btn-success">
+                            <i class="fas fa-tasks"></i> Create Action Items
+                        </button>
+                    </div>
+                </div>
             </div>
+            <!-- End of original summary.html content -->
         </div>
     </div>
 
-    <div class="card insights-card shadow mb-4">
-        <div class="card-header">
-            <h5>
-                <i class="fas fa-lightbulb"></i> AI-Generated Action Plan
-            </h5>
-        </div>
-        <div class="card-body insights-content">
-            {{ insights|default:"No insights available at the moment. Please check back later or ensure your financial data is up to date." }}
-        </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const sideNavbar = document.getElementById('sideNavbar');
+            const mobileToggle = document.getElementById('mobileToggle');
 
-        <div class="insights-actions">
-            <button class="btn btn-primary">
-                <i class="fas fa-download"></i> Export as PDF
-            </button>
-            <button class="btn btn-success">
-                <i class="fas fa-tasks"></i> Create Action Items
-            </button>
-        </div>
-    </div>
-</div>
-{% endblock %}
+            if (mobileToggle) {
+                mobileToggle.addEventListener('click', function() {
+                    sideNavbar.classList.toggle('active');
+                });
+            }
+
+            document.addEventListener('click', function(event) {
+                if (window.innerWidth <= 992) {
+                    const isClickInsideNavbar = sideNavbar.contains(event.target);
+                    const isClickOnToggle = mobileToggle.contains(event.target); // mobileToggle can be null if not found
+
+                    if (!isClickInsideNavbar && !isClickOnToggle && sideNavbar.classList.contains('active')) {
+                        sideNavbar.classList.remove('active');
+                    }
+                }
+            });
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
I've refactored `templates/summary.html` to adopt the same layout as `templates/dashboard.html` and `templates/analytics.html`. This includes incorporating the top navigation bar and the side navigation bar for a consistent user experience across these dashboard-related pages.

Changes:
- I modified `templates/summary.html` to remove `{% extends "base.html" %}`.
- I copied the structural HTML (top nav, side nav, content wrappers, CSS, and JS for sidebar functionality) from `dashboard.html` into `summary.html`.
- I integrated the original content of `summary.html` into the new layout's content area.
- I updated the side navigation in `summary.html` to:
    - Mark "AI Insights" as the active link.
    - Ensure "Chat" link points to the dashboard.
    - Ensure "Analytics" link points to the analytics page.
- I verified layout and navigation consistency.